### PR TITLE
terminal: all foregrounds and backgrounds need to be visible and readable

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -272,8 +272,8 @@ let s:gb.orange = s:orange
 " Setup Terminal Colors For Neovim: {{{
 
 if has('nvim')
-  let g:terminal_color_0 = s:bg0[0]
-  let g:terminal_color_8 = s:gray[0]
+  let g:terminal_color_0 = s:bg3[0]
+  let g:terminal_color_8 = s:bg4[0]
 
   let g:terminal_color_1 = s:gb.neutral_red[0]
   let g:terminal_color_9 = s:red[0]
@@ -294,7 +294,7 @@ if has('nvim')
   let g:terminal_color_14 = s:aqua[0]
 
   let g:terminal_color_7 = s:fg4[0]
-  let g:terminal_color_15 = s:fg1[0]
+  let g:terminal_color_15 = s:fg3[0]
 endif
 
 " }}}


### PR DESCRIPTION
This change isn't intuitive till you see it.

![before-and-after-dark.png](https://gist.github.com/bukzor-sentryio/57ed9bb5dec39dcc0b545c85065d0188/raw/891adda22d84673d577fa3156c5644545c244a40/before-and-after-dark.png)

![before-and-after-light.png](https://gist.github.com/bukzor-sentryio/57ed9bb5dec39dcc0b545c85065d0188/raw/891adda22d84673d577fa3156c5644545c244a40/before-and-after-light.png)

For an overly-detailed explanation, see https://github.com/wdomitrz/kitty-gruvbox-theme/pull/5